### PR TITLE
Variable names in bike example apps

### DIFF
--- a/example/model_simulated/graphite_bike_model_simulated.py
+++ b/example/model_simulated/graphite_bike_model_simulated.py
@@ -159,8 +159,8 @@ if __name__ == '__main__':
             unit=(ureg.m / ureg.sec), sampling_interval_sec=5,
             sampling_function=get_bike_speed)
     bike_speed.start_collecting()
-    bike_speed = graphite.create_metric(graphite_gateway, "model.bike.power",
+    bike_power = graphite.create_metric(graphite_gateway, "model.bike.power",
             unit=ureg.watt, sampling_interval_sec=5,
             sampling_function=get_bike_power)
-    bike_speed.start_collecting()
+    bike_power.start_collecting()
 

--- a/example/model_simulated/vrops_bike_model_simulated.py
+++ b/example/model_simulated/vrops_bike_model_simulated.py
@@ -179,10 +179,10 @@ if __name__ == '__main__':
                 unit=(ureg.m / ureg.sec), sampling_interval_sec=5,
                 sampling_function=get_bike_speed)
         bike_speed.start_collecting()
-        bike_speed = vrops.create_metric(vrops_bike, "Power",
+        bike_power = vrops.create_metric(vrops_bike, "Power",
                 unit=ureg.watt, sampling_interval_sec=5,
                 sampling_function=get_bike_power)
-        bike_speed.start_collecting()
+        bike_power.start_collecting()
     else:
         print "vROPS resource not registered successfully"
 


### PR DESCRIPTION
A minor fix on reused variable names in the two pint based bike simulation apps.