### PR TITLE
AWSIoT DCC, DCCComms and Example

### DIFF
--- a/examples/aws_iot/awsSampleProp.conf
+++ b/examples/aws_iot/awsSampleProp.conf
@@ -1,0 +1,9 @@
+#AWS IoT Configurations
+GatewayName = "TestGatewayName"
+AWSEndpoint = "<your_endpoint>.iot.<region>.amazonaws.com"
+AWSPort = 8883
+RootCAPath = "your rootCA path"
+ClientCertPath = "your client certificate path"
+PrivateKeyPath = "your private key path"
+ConnectDisconnectTimeout = 10
+OperationTimeout = 5

--- a/examples/aws_iot/home_simulated.py
+++ b/examples/aws_iot/home_simulated.py
@@ -33,7 +33,7 @@
 from liota.dcc_comms.aws_mqtt_dcc_comms import AWSMQTTDccComms
 from liota.dccs.aws_iot import AWSIoT
 from liota.entities.metrics.metric import Metric
-from liota.entities.devices.device import Device
+from liota.entities.devices.simulated_device import SimulatedDevice
 from AWSIoTPythonSDK.MQTTLib import AWSIoTMQTTClient
 from liota.entities.edge_systems.dell5k_edge_system import Dell5KEdgeSystem
 import random
@@ -134,8 +134,8 @@ if __name__ == '__main__':
     #  at topic 'TestGatewayName/CPUUtilization'
     reg_cpu_utilization.start_collecting()
 
-    #  Creating Device
-    dht_sensor = Device("SimulatedDHTSensor", None)
+    #  Creating Simulated Device
+    dht_sensor = SimulatedDevice("SimulatedDHTSensor")
     #  Registering Device and creating Parent-Child relationship
     reg_dht_sensor = aws.register_entity(reg_edge_system, dht_sensor)
     #  Creating Temperature Metric
@@ -168,8 +168,8 @@ if __name__ == '__main__':
     #  at topic 'TestGatewayName/SimulatedDHTSensor/LivingRoomHumidity'
     reg_hum_metric.start_collecting()
 
-    #  Creating Device
-    light_sensor = Device("SimDigLightSensor", None)
+    #  Creating Simulated Device
+    light_sensor = SimulatedDevice("SimDigLightSensor")
     #  Registering Device and creating Parent-Child relationship
     reg_light_sensor = aws.register_entity(reg_edge_system, light_sensor)
 

--- a/examples/aws_iot/home_simulated.py
+++ b/examples/aws_iot/home_simulated.py
@@ -114,7 +114,8 @@ if __name__ == '__main__':
 
     #  Initializing AWSMQTTDccComms with AWSIoT client object
     #  Connecting to AWS
-    #  Initializing AWS DCC using AWSMQTTDccComms object. QoS is 1 by default
+    #  Initializing AWS DCC using AWSMQTTDccComms object
+    #  QoS is 1 and enclose_metadata is False by default
     aws = AWSIoT(AWSMQTTDccComms(mqtt_client))
     print "Connected to AWS !"
     #  Registering EdgeSystem

--- a/examples/aws_iot/home_simulated.py
+++ b/examples/aws_iot/home_simulated.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------#
+#  Copyright © 2015-2016 VMware, Inc. All Rights Reserved.                    #
+#                                                                             #
+#  Licensed under the BSD 2-Clause License (the “License”); you may not use   #
+#  this file except in compliance with the License.                           #
+#                                                                             #
+#  The BSD 2-Clause License                                                   #
+#                                                                             #
+#  Redistribution and use in source and binary forms, with or without         #
+#  modification, are permitted provided that the following conditions are met:#
+#                                                                             #
+#  - Redistributions of source code must retain the above copyright notice,   #
+#      this list of conditions and the following disclaimer.                  #
+#                                                                             #
+#  - Redistributions in binary form must reproduce the above copyright        #
+#      notice, this list of conditions and the following disclaimer in the    #
+#      documentation and/or other materials provided with the distribution.   #
+#                                                                             #
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"#
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE  #
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE #
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE  #
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR        #
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF       #
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS   #
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN    #
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)    #
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF     #
+#  THE POSSIBILITY OF SUCH DAMAGE.                                            #
+# ----------------------------------------------------------------------------#
+
+from liota.dcc_comms.aws_mqtt_dcc_comms import AWSMQTTDccComms
+from liota.dccs.aws_iot import AWSIoT
+from liota.entities.metrics.metric import Metric
+from liota.entities.devices.device import Device
+from AWSIoTPythonSDK.MQTTLib import AWSIoTMQTTClient
+from liota.entities.edge_systems.dell5k_edge_system import Dell5KEdgeSystem
+import random
+import pint
+import psutil
+
+# getting aws related values from conf file
+aws_conf = {}
+execfile('awsSampleProp.conf', aws_conf)
+
+# create a pint unit registry
+ureg = pint.UnitRegistry()
+
+
+#  Reading CPU Utilization.
+def read_cpu_utilization(sample_duration_sec=1):
+    return round(psutil.cpu_percent(interval=sample_duration_sec), 2)
+
+
+#  Random number generator, simulating living room temperature readings.
+def living_room_temperature():
+    return random.randint(10, 30)
+
+
+#  Random number generator, simulating living room humidity readings.
+def living_room_humidity():
+    return random.randint(70, 90)
+
+
+#  Random number generator, simulating living room luminous readings.
+def living_room_luminance():
+    # 0 - Lights Off, 1 - Lights On
+    return random.randint(0, 1)
+
+# ---------------------------------------------------------------------------------
+# In this example, we demonstrate how data for a simulated metric generating
+# random numbers can be directed to AWS IoT data center component using Liota.
+#
+# A Simulated DHT sensor with Temperature and Humidity Metrics and a Simulated
+# Digital Light sensor with binary luminance Metrics are used.
+#
+# Liota uses AWSIoT SDK which uses MQTT as transport. Developers need not provide
+# MQTT tropics explicitly.  Publish topics are derived from Entity hierarchy
+# structure of Liota and slash separated Entity names are used as publish topics.
+#
+#
+#                                            Dell5kEdgeSystem
+#                                                   |
+#                                                   |
+#                                                   |
+#                     -----------------------------------------------------
+#                    |                              |                      |
+#                    |                              |                      |
+#                    |                              |                      |
+#                 DHT Sensor                 Digital Light Sensor    CPU Utilization
+#                    |                              |                   Metric
+#                    |                              |
+#            ----------------                  Light Metric
+#           |                |
+#           |                |
+#      Temperature        Humidity
+#         Metric           Metric
+#
+# The program illustrates the ease of use and manageability that Liota
+# brings to IoT application developers.
+
+
+if __name__ == '__main__':
+    #  Creating EdgeSystem
+    edge_system = Dell5KEdgeSystem(aws_conf['GatewayName'])
+
+    #  These are standard steps to be followed to connect with AWS IoT using AWS IoT SDK
+    mqtt_client = AWSIoTMQTTClient(aws_conf['GatewayName'])
+    mqtt_client.configureEndpoint(aws_conf['AWSEndpoint'], aws_conf['AWSPort'])
+    mqtt_client.configureCredentials(aws_conf['RootCAPath'], aws_conf['PrivateKeyPath'], aws_conf['ClientCertPath'])
+    mqtt_client.configureConnectDisconnectTimeout(aws_conf['ConnectDisconnectTimeout'])
+    mqtt_client.configureMQTTOperationTimeout(aws_conf['OperationTimeout'])
+
+    #  Initializing AWSMQTTDccComms with AWSIoT client object
+    #  Connecting to AWS
+    #  Initializing AWS DCC using AWSMQTTDccComms object. QoS is 1 by default
+    aws = AWSIoT(AWSMQTTDccComms(mqtt_client))
+    print "Connected to AWS !"
+    #  Registering EdgeSystem
+    reg_edge_system = aws.register_entity(edge_system, None)
+
+    #  Creating CPU Metric
+    cpu_utilization = Metric(
+        name="CPUUtilization",
+        unit=None,
+        interval=10,
+        aggregation_size=2,
+        sampling_function=read_cpu_utilization
+    )
+    #  Registering Metric and creating Parent-Child relationship
+    reg_cpu_utilization = aws.register_entity(reg_edge_system, cpu_utilization)
+    #  Publishing Registered CPU Utilization Metric to AWS
+    #  at topic 'TestGatewayName/CPUUtilization'
+    reg_cpu_utilization.start_collecting()
+
+    #  Creating Device
+    dht_sensor = Device("SimulatedDHTSensor", None)
+    #  Registering Device and creating Parent-Child relationship
+    reg_dht_sensor = aws.register_entity(reg_edge_system, dht_sensor)
+    #  Creating Temperature Metric
+    temp_metric = Metric(
+        name="LivingRoomTemperature",
+        entity_type="Metric",
+        unit=ureg.degC,
+        interval=1,
+        aggregation_size=5,
+        sampling_function=living_room_temperature
+    )
+    #  Registering Metric and creating Parent-Child relationship
+    reg_temp_metric = aws.register_entity(reg_dht_sensor, temp_metric)
+    #  Publishing Registered Temperature Metric to AWS
+    #  at topic 'TestGatewayName/SimulatedDHTSensor/LivingRoomTemperature'
+    reg_temp_metric.start_collecting()
+
+    #  Creating Humidity Metric
+    hum_metric = Metric(
+        name="LivingRoomHumidity",
+        entity_type="Metric",
+        unit=None,
+        interval=1,
+        aggregation_size=5,
+        sampling_function=living_room_humidity
+    )
+    #  Registering Metric and creating Parent-Child relationship
+    reg_hum_metric = aws.register_entity(reg_dht_sensor, hum_metric)
+    #  Publishing Registered Humidity Metric to AWS
+    #  at topic 'TestGatewayName/SimulatedDHTSensor/LivingRoomHumidity'
+    reg_hum_metric.start_collecting()
+
+    #  Creating Device
+    light_sensor = Device("SimDigLightSensor", None)
+    #  Registering Device and creating Parent-Child relationship
+    reg_light_sensor = aws.register_entity(reg_edge_system, light_sensor)
+
+    #  Creating Light Metric
+    light_metric = Metric(
+        name="LivingRoomLight",
+        entity_type="Metric",
+        unit=None,
+        interval=10,
+        aggregation_size=1,
+        sampling_function=living_room_luminance
+    )
+    #  Registering Metric and creating Parent-Child relationship
+    reg_light_metric = aws.register_entity(reg_light_sensor, light_metric)
+    #  Publishing Registered Light Metric to AWS
+    #  at topic 'TestGatewayName/SimDigLightSensor/LivingRoomLight'
+    reg_light_metric.start_collecting()

--- a/liota/dcc_comms/aws_mqtt_dcc_comms.py
+++ b/liota/dcc_comms/aws_mqtt_dcc_comms.py
@@ -1,0 +1,99 @@
+
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------#
+#  Copyright © 2015-2016 VMware, Inc. All Rights Reserved.                    #
+#                                                                             #
+#  Licensed under the BSD 2-Clause License (the “License”); you may not use   #
+#  this file except in compliance with the License.                           #
+#                                                                             #
+#  The BSD 2-Clause License                                                   #
+#                                                                             #
+#  Redistribution and use in source and binary forms, with or without         #
+#  modification, are permitted provided that the following conditions are met:#
+#                                                                             #
+#  - Redistributions of source code must retain the above copyright notice,   #
+#      this list of conditions and the following disclaimer.                  #
+#                                                                             #
+#  - Redistributions in binary form must reproduce the above copyright        #
+#      notice, this list of conditions and the following disclaimer in the    #
+#      documentation and/or other materials provided with the distribution.   #
+#                                                                             #
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"#
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE  #
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE #
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE  #
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR        #
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF       #
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS   #
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN    #
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)    #
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF     #
+#  THE POSSIBILITY OF SUCH DAMAGE.                                            #
+# ----------------------------------------------------------------------------#
+
+import logging
+import sys
+from dcc_comms import DCCComms
+from AWSIoTPythonSDK.MQTTLib import AWSIoTMQTTShadowClient
+from AWSIoTPythonSDK.MQTTLib import AWSIoTMQTTClient
+
+log = logging.getLogger(__name__)
+
+
+class AWSMQTTDccComms(DCCComms):
+    """
+        This DCCComms leverages AWS provided device SDK.
+        https://github.com/aws/aws-iot-device-sdk-python
+
+        AWS SDK built on top of a modified Paho MQTT Python client library.
+
+        Key features of AWS SDK are:
+        1. Progressive reconnect back off
+        2. Offline Publish requests queueing with Draining
+        3. Persistent/Non-Persistent subscription
+        4. Device shadow with token and version tracing
+        5. MQTT over WebSocket with IAM/SigV4
+    """
+
+    def __init__(self, mqtt_client):
+        #  Validating client type
+        if isinstance(mqtt_client, AWSIoTMQTTClient) or isinstance(mqtt_client, AWSIoTMQTTShadowClient):
+            self.mqtt_client = mqtt_client
+        else:
+            raise TypeError("AWSIoTMQTTClient or AWSIoTMQTTShadowClient is expected.")
+        self._connect()
+
+    def _connect(self):
+        try:
+            self.mqtt_client.connect()
+            log.debug("Connected to AWS IoT")
+        except Exception:
+            log.exception("AWSIoT Connection Exception traceback")
+            sys.exit(0)
+
+    def _disconnect(self):
+        if self.mqtt_client:
+            self.mqtt_client.disconnect()
+        log.debug("Disconnected")
+
+    def publish(self, topic, payload, qos=1):
+        try:
+            if isinstance(self.mqtt_client, AWSIoTMQTTClient):
+                #  Publish using AWSIoTMQTTClient
+                self.mqtt_client.publish(topic, payload, qos)
+            else:
+                #  Publish using AWSIoTMQTTShadowClient
+                self.mqtt_client.getMQTTConnection().publish(topic, payload, qos)
+            log.debug("Published Topic:{0}, Payload:{1}, QoS:{2}".format(topic, payload, qos))
+        except Exception:
+            log.exception("AWSIoT Exception while publishing "
+                          "Topic:{0}, Payload:{1}, QoS:{2}".format(topic, payload, qos))
+
+    def subscribe(self):
+        raise NotImplementedError
+
+    def send(self, message):
+        raise NotImplementedError
+
+    def receive(self):
+        raise NotImplementedError

--- a/liota/dccs/aws_iot.py
+++ b/liota/dccs/aws_iot.py
@@ -1,0 +1,167 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------#
+#  Copyright © 2015-2016 VMware, Inc. All Rights Reserved.                    #
+#                                                                             #
+#  Licensed under the BSD 2-Clause License (the “License”); you may not use   #
+#  this file except in compliance with the License.                           #
+#                                                                             #
+#  The BSD 2-Clause License                                                   #
+#                                                                             #
+#  Redistribution and use in source and binary forms, with or without         #
+#  modification, are permitted provided that the following conditions are met:#
+#                                                                             #
+#  - Redistributions of source code must retain the above copyright notice,   #
+#      this list of conditions and the following disclaimer.                  #
+#                                                                             #
+#  - Redistributions in binary form must reproduce the above copyright        #
+#      notice, this list of conditions and the following disclaimer in the    #
+#      documentation and/or other materials provided with the distribution.   #
+#                                                                             #
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"#
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE  #
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE #
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE  #
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR        #
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF       #
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS   #
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN    #
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)    #
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF     #
+#  THE POSSIBILITY OF SUCH DAMAGE.                                            #
+# ----------------------------------------------------------------------------#
+
+from liota.dccs.dcc import DataCenterComponent
+from liota.entities.edge_systems.edge_system import EdgeSystem
+from liota.entities.devices.device import Device
+from liota.entities.metrics.metric import Metric
+from liota.entities.metrics.registered_metric import RegisteredMetric
+from liota.entities.registered_entity import RegisteredEntity
+from liota.lib.utilities.si_unit import parse_unit
+from collections import OrderedDict
+import json
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class AWSIoT(DataCenterComponent):
+    """
+    DCC for AWS IoT platform. AWSMQTTDccComms is used as transport
+    """
+    def __init__(self, con, qos=1):
+        """
+        :param con: AWSMQTTDccComms Object
+        :param qos: 0 or 1
+        """
+        super(AWSIoT, self).__init__(con)
+        if qos in range(0, 2):
+            self.qos = qos
+        else:
+            raise ValueError("QoS must either be 0 or 1")
+
+    def register_entity(self, parent_entity, child_entity):
+        """
+        Returns RegisteredEntity and also creates Parent-Child Relationship
+
+        :param parent_entity: EdgeSystem or a RegisteredEntity Object
+        :param child_entity: Device or a Metric Object or None
+        :return: RegisteredEntity or RegisteredMetric
+        """
+        if isinstance(parent_entity, EdgeSystem) and child_entity is None:
+            return RegisteredEntity(parent_entity, self, None)
+
+        elif isinstance(parent_entity, RegisteredEntity) and isinstance(child_entity, Device):
+            reg_entity = RegisteredEntity(child_entity, self, None)
+            self.create_relationship(parent_entity, reg_entity)
+            return reg_entity
+
+        elif isinstance(parent_entity, RegisteredEntity) and isinstance(child_entity, Metric):
+            reg_metric = RegisteredMetric(child_entity, self, None)
+            self.create_relationship(parent_entity, reg_metric)
+            return reg_metric
+
+        else:
+            log.error("Illegal Registration attempted between Parent Entity:{0} and Child Entity:{1}".
+                      format(parent_entity, child_entity))
+            raise TypeError("Illegal Registration attempted.")
+
+    def create_relationship(self, reg_entity_parent, reg_entity_child):
+        """
+        This method creates Parent-Child relationship.  Supported relationships are:
+
+               EdgeSystem
+                   |                                      EdgeSystem
+                Device                   (or)                |
+                   |                                    RegisteredMetric
+             RegisteredMetric
+
+        However, A single EdgeSystem can have multiple child Devices and a each Device can have
+        multiple child Metrics.
+
+        :param reg_entity_parent: Registered EdgeSystem or Device Object
+        :param reg_entity_child:  Registered Device or Metric Object
+        :return: None
+        """
+        if not isinstance(reg_entity_parent.ref_entity, EdgeSystem) and \
+                not isinstance(reg_entity_parent.ref_entity, Device):
+            raise TypeError("reg_entity_parent should either be a Registered EdgeSystem or a Device")
+
+        if not isinstance(reg_entity_child.ref_entity, Device) and \
+                not isinstance(reg_entity_child, RegisteredMetric):
+            raise TypeError("reg_entity_child should either be a Registered Device or Metric")
+
+        reg_entity_child.parent = reg_entity_parent
+
+    def _get_publish_topic(self, reg_metric):
+        """
+        :param reg_metric: RegisteredMetric Object
+        :return: MQTT publish topic based on Parent Child relationship
+        """
+        if not isinstance(reg_metric, RegisteredMetric):
+            raise TypeError("RegisteredMetric is expected")
+
+        def extract_topic(reg_entity):
+            """
+            Recursive function for extracting topic
+            :param reg_entity: RegisteredEntity Object
+            :return:
+            """
+            if reg_entity is None:
+                return ""
+            else:
+                return extract_topic(reg_entity.parent) + reg_entity.ref_entity.name + '/'
+
+        return extract_topic(reg_metric.parent) + reg_metric.ref_entity.name
+
+    def _format_data(self, reg_metric):
+        """
+        :param reg_metric: Registered Metric Object
+        :return: Payload in JSON format
+        """
+        list = []
+        met_cnt = reg_metric.values.qsize()
+        if met_cnt > 0:
+            for _ in range(met_cnt):
+                m = reg_metric.values.get(block=True)
+                if m is not None:
+                    list.append(OrderedDict([('value', m[1]), ('timestamp', m[0])]))
+        payload = OrderedDict()
+        payload['metric_data'] = [_ for _ in list]
+        payload['unit'] = parse_unit(reg_metric.ref_entity.unit)[1]
+
+        return json.dumps(payload)
+
+    def publish(self, reg_metric):
+        """
+        Publishes message to AWS IoT in JSON format.
+        :param metric: Registered Metric Object
+        :return: None
+        """
+        log.debug("Publishing to AWS IoT")
+        self.comms.publish(self._get_publish_topic(reg_metric), self._format_data(reg_metric), self.qos)
+
+    def set_properties(self, reg_entity, properties):
+        raise NotImplementedError
+
+    def register(self, entity_obj):
+        raise NotImplementedError

--- a/packages/awsSampleProp.conf
+++ b/packages/awsSampleProp.conf
@@ -1,0 +1,9 @@
+#AWS IoT Configurations
+GatewayName = "TestGatewayName"
+AWSEndpoint = "<your_endpoint>.iot.<region>.amazonaws.com"
+AWSPort = 8883
+RootCAPath = "your rootCA path"
+ClientCertPath = "your client certificate path"
+PrivateKeyPath = "your private key path"
+ConnectDisconnectTimeout = 10
+OperationTimeout = 5

--- a/packages/aws_iot.py
+++ b/packages/aws_iot.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------#
+#  Copyright © 2015-2016 VMware, Inc. All Rights Reserved.                    #
+#                                                                             #
+#  Licensed under the BSD 2-Clause License (the “License”); you may not use   #
+#  this file except in compliance with the License.                           #
+#                                                                             #
+#  The BSD 2-Clause License                                                   #
+#                                                                             #
+#  Redistribution and use in source and binary forms, with or without         #
+#  modification, are permitted provided that the following conditions are met:#
+#                                                                             #
+#  - Redistributions of source code must retain the above copyright notice,   #
+#      this list of conditions and the following disclaimer.                  #
+#                                                                             #
+#  - Redistributions in binary form must reproduce the above copyright        #
+#      notice, this list of conditions and the following disclaimer in the    #
+#      documentation and/or other materials provided with the distribution.   #
+#                                                                             #
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"#
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE  #
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE #
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE  #
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR        #
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF       #
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS   #
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN    #
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)    #
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF     #
+#  THE POSSIBILITY OF SUCH DAMAGE.                                            #
+# ----------------------------------------------------------------------------#
+
+from liota.core.package_manager import LiotaPackage
+
+dependencies = ["edge_systems/dell5k/edge_system"]
+
+
+class PackageClass(LiotaPackage):
+    """
+    This package creates a AWSIoT DCC object and registers edge system on
+    AWSIoT to acquire "registered edge system", i.e. aws_iot_edge_system.
+    """
+
+    def run(self, registry):
+        import copy
+        from AWSIoTPythonSDK.MQTTLib import AWSIoTMQTTClient
+        from liota.dccs.aws_iot import AWSIoT
+        from liota.dcc_comms.aws_mqtt_dcc_comms import AWSMQTTDccComms
+
+        # Acquire resources from registry
+        # Creating a copy of edge_system object to keep original object "clean"
+        edge_system = copy.copy(registry.get("edge_system"))
+
+        # Get values from configuration file
+        config_path = registry.get("package_conf")
+        aws_conf = {}
+        execfile(config_path + '/awsSampleProp.conf', aws_conf)
+
+        #  These are standard steps to be followed to connect with AWS IoT using AWS IoT SDK
+        mqtt_client = AWSIoTMQTTClient(aws_conf['GatewayName'])
+        mqtt_client.configureEndpoint(aws_conf['AWSEndpoint'], aws_conf['AWSPort'])
+        mqtt_client.configureCredentials(aws_conf['RootCAPath'], aws_conf['PrivateKeyPath'], aws_conf['ClientCertPath'])
+        mqtt_client.configureConnectDisconnectTimeout(aws_conf['ConnectDisconnectTimeout'])
+        mqtt_client.configureMQTTOperationTimeout(aws_conf['OperationTimeout'])
+
+        #  Initializing AWSMQTTDccComms with AWSIoT client object
+        #  Connecting to AWS
+        #  Initializing AWS DCC using AWSMQTTDccComms object
+        #  QoS is 1 and enclose_metadata is False by default
+        self.aws_iot = AWSIoT(AWSMQTTDccComms(mqtt_client))
+
+        # Register edge system (gateway)
+        aws_iot_edge_system = self.aws_iot.register_entity(edge_system, None)
+
+        registry.register("aws_iot", self.aws_iot)
+        registry.register("aws_iot_edge_system", aws_iot_edge_system)
+
+    def clean_up(self):
+        self.aws_iot.comms._disconnect()

--- a/packages/examples/aws_iot_home_simulated.py
+++ b/packages/examples/aws_iot_home_simulated.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------#
+#  Copyright © 2015-2016 VMware, Inc. All Rights Reserved.                    #
+#                                                                             #
+#  Licensed under the BSD 2-Clause License (the “License”); you may not use   #
+#  this file except in compliance with the License.                           #
+#                                                                             #
+#  The BSD 2-Clause License                                                   #
+#                                                                             #
+#  Redistribution and use in source and binary forms, with or without         #
+#  modification, are permitted provided that the following conditions are met:#
+#                                                                             #
+#  - Redistributions of source code must retain the above copyright notice,   #
+#      this list of conditions and the following disclaimer.                  #
+#                                                                             #
+#  - Redistributions in binary form must reproduce the above copyright        #
+#      notice, this list of conditions and the following disclaimer in the    #
+#      documentation and/or other materials provided with the distribution.   #
+#                                                                             #
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"#
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE  #
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE #
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE  #
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR        #
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF       #
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS   #
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN    #
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)    #
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF     #
+#  THE POSSIBILITY OF SUCH DAMAGE.                                            #
+# ----------------------------------------------------------------------------#
+
+import random
+import psutil
+from liota.core.package_manager import LiotaPackage
+
+dependencies = ["aws_iot"]
+
+
+#  Reading CPU Utilization.
+def read_cpu_utilization(sample_duration_sec=1):
+    return round(psutil.cpu_percent(interval=sample_duration_sec), 2)
+
+
+#  Random number generator, simulating living room temperature readings.
+def living_room_temperature():
+    return random.randint(10, 30)
+
+
+#  Random number generator, simulating living room humidity readings.
+def living_room_humidity():
+    return random.randint(70, 90)
+
+
+#  Random number generator, simulating living room luminous readings.
+def living_room_luminance():
+    # 0 - Lights Off, 1 - Lights On
+    return random.randint(0, 1)
+
+
+class PackageClass(LiotaPackage):
+    #  TODO: CHECK Warning: could not de-register resource refs. Package Manager line No: 680
+
+    def run(self, registry):
+        import pint
+        import copy
+        from liota.entities.metrics.metric import Metric
+        from liota.entities.devices.simulated_device import SimulatedDevice
+
+        # create a pint unit registry
+        ureg = pint.UnitRegistry()
+
+        # Acquire resources from registry
+        aws_iot = registry.get("aws_iot")
+        aws_iot_edge_system = copy.copy(registry.get("aws_iot_edge_system"))
+
+        # Create metrics
+        self.metrics = []
+        metric_cpu_utilization = Metric(
+            name="CPUUtilization",
+            unit=None,
+            interval=5,
+            aggregation_size=1,
+            sampling_function=read_cpu_utilization
+        )
+        reg_metric_cpu_utilization = aws_iot.register_entity(aws_iot_edge_system, metric_cpu_utilization)
+        reg_metric_cpu_utilization.start_collecting()
+        self.metrics.append(reg_metric_cpu_utilization)
+
+        #  Creating Simulated Device
+        dht_sensor = SimulatedDevice("SimulatedDHTSensor")
+        #  Registering Device and creating Parent-Child relationship
+        reg_dht_sensor = aws_iot.register_entity(aws_iot_edge_system, dht_sensor)
+
+        #  Creating Temperature Metric
+        temp_metric = Metric(
+            name="LivingRoomTemperature",
+            entity_type="Metric",
+            unit=ureg.degC,
+            interval=1,
+            aggregation_size=5,
+            sampling_function=living_room_temperature
+        )
+        #  Registering Metric and creating Parent-Child relationship
+        reg_temp_metric = aws_iot.register_entity(reg_dht_sensor, temp_metric)
+        #  Publishing Registered Temperature Metric to AWS
+        reg_temp_metric.start_collecting()
+        self.metrics.append(reg_temp_metric)
+
+        #  Creating Humidity Metric
+        hum_metric = Metric(
+            name="LivingRoomHumidity",
+            entity_type="Metric",
+            unit=None,
+            interval=1,
+            aggregation_size=5,
+            sampling_function=living_room_humidity
+        )
+        #  Registering Metric and creating Parent-Child relationship
+        reg_hum_metric = aws_iot.register_entity(reg_dht_sensor, hum_metric)
+        #  Publishing Registered Humidity Metric to AWS
+        reg_hum_metric.start_collecting()
+        self.metrics.append(reg_hum_metric)
+
+        #  Creating Simulated Device
+        light_sensor = SimulatedDevice("SimDigLightSensor")
+        #  Registering Device and creating Parent-Child relationship
+        reg_light_sensor = aws_iot.register_entity(aws_iot_edge_system, light_sensor)
+
+        #  Creating Light Metric
+        light_metric = Metric(
+            name="LivingRoomLight",
+            entity_type="Metric",
+            unit=None,
+            interval=10,
+            aggregation_size=1,
+            sampling_function=living_room_luminance
+        )
+        #  Registering Metric and creating Parent-Child relationship
+        reg_light_metric = aws_iot.register_entity(reg_light_sensor, light_metric)
+        #  Publishing Registered Light Metric to AWS
+        reg_light_metric.start_collecting()
+        self.metrics.append(reg_light_metric)
+
+    def clean_up(self):
+        for metric in self.metrics:
+            metric.stop_collecting()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 websocket-client==0.37.0
 psutil==4.3.1
 pint==0.7.2
-AWSIoTPythonSDK==1.0.0
+AWSIoTPythonSDK==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 websocket-client==0.37.0
 psutil==4.3.1
 pint==0.7.2
+AWSIoTPythonSDK==1.0.0


### PR DESCRIPTION
`AWSMQTTDccComms:`
- Uses [AWSIoTPythonSDK](https://github.com/aws/aws-iot-device-sdk-python).
- `init()` accepts AWSIoT object because, there are lot of parameters to be handled to enclose it as part of init() apart from credentials. Refer [here](https://github.com/aws/aws-iot-device-sdk-python/blob/master/samples/basicPubSub/basicPubSub.py#L129).  By using it this way,  DCC would be compatible with future versions AWS SDK also.

`AWSIoT DCC:` 
- Publish topic is generated based on Parent-Child hierarchy.  
- Added register_entity() to call create_relationship() as part of registration itself to make it much more easier for clients.
- Message published in JSON format.

`AWSIoT Package Manager:`
- Added.

`Unit & Integration TestSuites:`
- Will be added once this PR is accepted.
