### PR TITLE
Package Manager and Device Discovery Improvement (6):

### DIFF
--- a/config/liota.conf
+++ b/config/liota.conf
@@ -32,7 +32,7 @@ Banana23 = serial
 [DEVICE_TYPE_TO_DCC_MAPPING]
 LM35 = graphite, iotcc_mqtt, iotcc
 Press64 = iotcc_mqtt, iotcc
-Apple56 = iotcc_mqtt
+Apple56 = iotcc_mqtt, iotcc
 Banana23 = iotcc
 
 [DEVSIM_CFG]

--- a/liota/core/device_discovery.py
+++ b/liota/core/device_discovery.py
@@ -32,7 +32,6 @@
 
 import logging
 import os
-import sys
 import fcntl
 import errno
 import ConfigParser
@@ -512,7 +511,7 @@ class DiscoveryThread(Thread):
                         reg_rec[dcc] = (dev, reg_dev)
                         self._update_devinfo(name, reg_rec)
         except:
-            log.exception("device_msg_process error:{0}".format(sys.exc_info()[0]))
+            log.exception("device_msg_process exception")
 
 class CmdMessengerThread(Thread):
     """

--- a/liota/core/package_manager.py
+++ b/liota/core/package_manager.py
@@ -33,7 +33,6 @@
 import logging
 import imp
 import os
-import sys
 import fcntl
 import stat
 import re
@@ -464,7 +463,7 @@ class PackageThread(Thread):
         if not (path_file.startswith(os.path.abspath(package_path)+'/')):
             log.error("Package %s is NOT under package path %s"
                          % (file_name, package_path))
-            return None, None
+            return None, None, None
 
         file_ext = None
         extensions = ["py", "pyc", "pyo"]
@@ -492,7 +491,7 @@ class PackageThread(Thread):
             else:
                 log.error("Package file not found: %s"
                           % (path_file + "." + ext_forced))
-            return None, None
+            return None, None, None
         path_file_ext = path_file + "." + file_ext
         log.debug("Package file found: %s" % path_file_ext)
         return path_file_ext, file_ext, checksum_list
@@ -834,7 +833,7 @@ class PackageThread(Thread):
                     if not self._package_load(file_name, checksum):
                         list_failed.append(file_name)
             except:
-                log.exception("_package_load_list error:{0}".format(sys.exc_info()[0]))
+                log.exception("_package_load_list exception")
         if len(list_failed) > 0:
             log.warning("Some packages specified in list failed to load: %s"
                         % " ".join(list_failed))
@@ -878,7 +877,7 @@ class PackageThread(Thread):
                 for filename, checksum in file_string.items():
                     filename_list.append(filename)
             except:
-                log.exception("_package_update_list error:{0}".format(sys.exc_info()[0]))
+                log.exception("_package_update_list exception")
         flag_failed = False
 
         # Acquire a list of all dependents of these packages

--- a/liota/dev_sims/mqtt.py
+++ b/liota/dev_sims/mqtt.py
@@ -80,7 +80,7 @@ class MqttSimulator(DeviceSimulator):
             # Encapsulate TLS parameters
             self.tls_conf = TLSConf(mqtt_cfg['cert_required'], mqtt_cfg['tls_version'], mqtt_cfg['cipher'])
         # Encapsulate QoS related parameters
-        self.qos_details = QoSDetails(mqtt_cfg['in_flight'], mqtt_cfg['queue_size'], mqtt_cfg['retry'])
+        self.qos_details = QoSDetails(mqtt_cfg['in_flight'], int(mqtt_cfg['queue_size']), mqtt_cfg['retry'])
         # Create MQTT connection object with required params
         self.mqtt_conn = MqttDeviceComms(url=self.broker_ip, port=int(self.broker_port), identity=self.identity,
                                          tls_conf=self.tls_conf, qos_details=self.qos_details,  clean_session=True,

--- a/liota/disc_listeners/mqtt.py
+++ b/liota/disc_listeners/mqtt.py
@@ -93,7 +93,11 @@ class MqttListener(DiscoveryListener):
         if self.flag_alive:
             # Acquire resources from registry
             if (self.discovery is not None):
-                self.edge_system_object = copy.copy(self.discovery.pkg_registry.get("edge_system"))
+                try:
+                    self.edge_system_object = copy.copy(self.discovery.pkg_registry.get("edge_system"))
+                except:
+                    log.exception("disc_listeners mqtt run exception")
+                    return
             else:
                 log.error("discovery.pkg_registry is None; could not start MqttListener!")
                 return

--- a/packages/README.md
+++ b/packages/README.md
@@ -11,7 +11,10 @@ Currently, supported commands include package action commands and statistical co
 
 * **load** package_name sha1_checksum [package_name sha1_checksum] ...
 
-Load a package with the specified name and its sha1 checksum. If the specified package provides with a list of dependencies, recursively load all its dependencies. If more than one package names are specified, load them (as well as their dependencies) in a batch and no package will be loaded twice or reloaded.
+Load a package with the specified name and its sha1 checksum. For example, linux os user can first use "sha1sum filename" cmd to get checksum, and then load package by
+"./liotapkg.sh load filename sha1_checksum".
+
+If the specified package provides with a list of dependencies, recursively load all its dependencies. If more than one package names are specified, load them (as well as their dependencies) in a batch and no package will be loaded twice or reloaded.
 
 Liota packages must follow certain formats for package manager to process them correctly. It is up to the package developer to follow the format requirements. Details will be provided in later parts of this document. Please also refer to `packages` and `packages/example` for example packages we have provided.
 

--- a/packages/dev_disc/README.md
+++ b/packages/dev_disc/README.md
@@ -68,7 +68,7 @@ disc_msg_pipe = /etc/liota/packages/dev_disc/discovery_messenger.fifo	# currentl
 
 socket = 127.0.0.1:5000						# coap and socket are not allowed for security consideration).
 
-mqtt = 127.0.0.1:1023:device_discovery		# Mqtt broker should be started first before publish/subscribe
+mqtt = 127.0.0.1:1882:device_discovery		# Mqtt broker should be started first before publish/subscribe
 
 coap = 127.0.0.1:5683					# reference: https://mosquitto.org/download/
 
@@ -105,7 +105,7 @@ retry = 5
 keep_alive = 60
 
 ConnectDisconnectTimeout = 10
-* When MQTT broker also sits on the edge system, MQTT subscriber can listen on 127.0.0.1/localhost with port < 1024 and use basic authentication
+* When MQTT broker also sits on the edge system, MQTT subscriber can listen on 127.0.0.1/localhost with a unique port (rather than well-known 1883) and use basic authentication
 to guarantee secured communication with MQTT broker. It's MQTT broker and MQTT publisher's responsibility to guarantee MQTT broker and external world communicate securely.
 
 # Configuration B (under /etc/liota/packages, inside sampleProf.conf)


### PR DESCRIPTION
1. When mqtt broker listens on a port < 1024, client connection will
be refused, so remind user to listen on a unique port rather than
well-known port 1883
2. correct _package_chk_exists() return None minor issue
3. improve exception logging