### PR TITLE
change path of liota generated files; remove bash command requirement

### DIFF
--- a/config/liota.conf
+++ b/config/liota.conf
@@ -4,13 +4,10 @@ json_path = /etc/liota/logging.json
 [LOG_PATH]
 log_path = /var/log/liota
 
-[UUID_PATH]
-uuid_path = /etc/liota/uuid.ini
-
 [IOTCC_PATH]
-dev_file_path = /etc/liota/conf/devs
-entity_file_path = /etc/liota/conf/entity
-iotcc_path = /etc/liota/conf/iotcc.json
+dev_file_path = /var/tmp/liota/devs
+entity_file_path = /usr/lib/liota/entity
+iotcc_path = /var/tmp/liota/iotcc.json
 
 [CORE_CFG]
 collect_thread_pool_size = 30
@@ -21,7 +18,7 @@ pkg_msg_pipe = /var/tmp/liota/package_messenger.fifo
 pkg_list = /usr/lib/liota/packages/packages_auto.txt
 
 [DISC_CFG]
-disc_cmd_msg_pipe = /usr/lib/liota/packages/dev_disc/disc_cmd_messenger.fifo
+disc_cmd_msg_pipe = /var/tmp/liota/packages/dev_disc/disc_cmd_messenger.fifo
 
 [DEVICE_TYPE_TO_UNIQUEKEY_MAPPING]
 Press64 = serial
@@ -36,10 +33,10 @@ Apple56 = iotcc_mqtt, iotcc
 Banana23 = iotcc
 
 [DEVSIM_CFG]
-devsim_cmd_msg_pipe = /usr/lib/liota/packages/dev_disc/devsim_cmd_messenger.fifo
+devsim_cmd_msg_pipe = /var/tmp/liota/packages/dev_disc/devsim_cmd_messenger.fifo
 
 [DISC_ENDPOINT_LIST]
-disc_msg_pipe = /usr/lib/liota/packages/dev_disc/discovery_messenger.fifo
+disc_msg_pipe = /var/tmp/liota/packages/dev_disc/discovery_messenger.fifo
 
 [DISC_MQTT_CFG]
 enable_authentication = True

--- a/config/liota.conf
+++ b/config/liota.conf
@@ -14,7 +14,7 @@ collect_thread_pool_size = 30
 
 [PKG_CFG]
 pkg_path = /usr/lib/liota/packages
-pkg_msg_pipe = /usr/lib/liota/package_messenger.fifo
+pkg_msg_pipe = /usr/lib/liota/packages/package_messenger.fifo
 pkg_list = /usr/lib/liota/packages/packages_auto.txt
 
 [DISC_CFG]

--- a/config/liota.conf
+++ b/config/liota.conf
@@ -5,9 +5,9 @@ json_path = /etc/liota/logging.json
 log_path = /var/log/liota
 
 [IOTCC_PATH]
-dev_file_path = /var/tmp/liota/devs
+dev_file_path = /usr/lib/liota/devs
 entity_file_path = /usr/lib/liota/entity
-iotcc_path = /var/tmp/liota/iotcc.json
+iotcc_path = /usr/lib/liota/iotcc.json
 
 [CORE_CFG]
 collect_thread_pool_size = 30

--- a/config/liota.conf
+++ b/config/liota.conf
@@ -14,11 +14,11 @@ collect_thread_pool_size = 30
 
 [PKG_CFG]
 pkg_path = /usr/lib/liota/packages
-pkg_msg_pipe = /var/tmp/liota/package_messenger.fifo
+pkg_msg_pipe = /usr/lib/liota/package_messenger.fifo
 pkg_list = /usr/lib/liota/packages/packages_auto.txt
 
 [DISC_CFG]
-disc_cmd_msg_pipe = /var/tmp/liota/packages/dev_disc/disc_cmd_messenger.fifo
+disc_cmd_msg_pipe = /usr/lib/liota/packages/dev_disc/disc_cmd_messenger.fifo
 
 [DEVICE_TYPE_TO_UNIQUEKEY_MAPPING]
 Press64 = serial
@@ -33,10 +33,10 @@ Apple56 = iotcc_mqtt, iotcc
 Banana23 = iotcc
 
 [DEVSIM_CFG]
-devsim_cmd_msg_pipe = /var/tmp/liota/packages/dev_disc/devsim_cmd_messenger.fifo
+devsim_cmd_msg_pipe = /usr/lib/liota/packages/dev_disc/devsim_cmd_messenger.fifo
 
 [DISC_ENDPOINT_LIST]
-disc_msg_pipe = /var/tmp/liota/packages/dev_disc/discovery_messenger.fifo
+disc_msg_pipe = /usr/lib/liota/packages/dev_disc/discovery_messenger.fifo
 
 [DISC_MQTT_CFG]
 enable_authentication = True

--- a/liota/dcc_comms/mqtt_dcc_comms.py
+++ b/liota/dcc_comms/mqtt_dcc_comms.py
@@ -35,7 +35,7 @@ import Queue
 
 from liota.dcc_comms.dcc_comms import DCCComms
 from liota.lib.transports.mqtt import Mqtt, MqttMessagingAttributes
-from liota.lib.utilities.utility import store_edge_system_uuid, systemUUID
+from liota.lib.utilities.utility import systemUUID
 
 log = logging.getLogger(__name__)
 
@@ -84,10 +84,6 @@ class MqttDccComms(DCCComms):
                 log.info("generated local uuid will be the client ID")
             else:
                 log.info("Client ID is provided by user")
-            # Storing edge_system name and generated local_uuid which will be used in auto-generation of pub-sub topic
-            store_edge_system_uuid(entity_name=edge_system_name,
-                                   entity_id=self.client_id,
-                                   reg_entity_id=None)
         elif isinstance(mqtt_msg_attr, MqttMessagingAttributes):
             log.info("User configured pub-topic and sub-topic")
             self.msg_attr = mqtt_msg_attr

--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -43,7 +43,7 @@ from threading import Lock
 from liota.dccs.dcc import DataCenterComponent, RegistrationFailure
 from liota.lib.protocols.helix_protocol import HelixProtocol
 from liota.entities.metrics.metric import Metric
-from liota.lib.utilities.utility import LiotaConfigPath, getUTCmillis, mkdir, read_liota_config, store_edge_system_uuid
+from liota.lib.utilities.utility import LiotaConfigPath, getUTCmillis, mkdir, read_liota_config
 from liota.lib.utilities.si_unit import parse_unit
 from liota.entities.metrics.registered_metric import RegisteredMetric
 from liota.entities.registered_entity import RegisteredEntity
@@ -138,8 +138,6 @@ class IotControlCenter(DataCenterComponent):
             if entity_obj.entity_type == "HelixGateway":
                 self.store_reg_entity_details(entity_obj.entity_type, entity_obj.name, self.reg_entity_id,
                                               entity_obj.entity_id)
-                store_edge_system_uuid(entity_name=entity_obj.name, entity_id=entity_obj.entity_id,
-                                       reg_entity_id=self.reg_entity_id)
                 with self.file_ops_lock:
                     self.store_reg_entity_attributes("EdgeSystem", entity_obj.name,
                                                      self.reg_entity_id, None, None)

--- a/liota/lib/utilities/utility.py
+++ b/liota/lib/utilities/utility.py
@@ -161,32 +161,6 @@ def mkdir(path):
             else:
                 raise
 
-
-def store_edge_system_uuid(entity_name, entity_id, reg_entity_id):
-    """
-    Utility function to store EdgeSystem's Name, local-uuid and registered-uuid in the
-    specified file.
-    :param entity_name: EdgeSystem's Name
-    :param entity_id: Local uuid of the EdgeSystem
-    :param reg_entity_id: Registered uuid of the EdgeSystem
-    :return: None
-    """
-    try:
-        uuid_path = read_liota_config('UUID_PATH', 'uuid_path')
-        uuid_config = ConfigParser.RawConfigParser()
-        uuid_config.optionxform = str
-        uuid_config.add_section('GATEWAY')
-        uuid_config.set('GATEWAY', 'name', entity_name)
-        if entity_id:
-            uuid_config.set('GATEWAY', 'local-uuid', entity_id)
-        if reg_entity_id:
-            uuid_config.set('GATEWAY', 'registered-uuid', reg_entity_id)
-        with open(uuid_path, 'w') as configfile:
-            uuid_config.write(configfile)
-    except ConfigParser.ParsingError, err:
-        log.error('Could not open config file ' + str(err))
-
-
 def sha1sum(path_file):
     """
     This method calculates SHA-1 checksum of file.

--- a/packages/dev_disc/liota_devsim_pipe.sh
+++ b/packages/dev_disc/liota_devsim_pipe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------#
 #  Copyright © 2015-2016 VMware, Inc. All Rights Reserved.                    #
@@ -34,31 +34,33 @@
 liota_config="/etc/liota/liota.conf"
 discovery_messenger_pipe=""
 
-if [ ! -f "$liota_config" ]; then
+if [ ! -f "$liota_config" ]
+then
     echo "ERROR: Configuration file not found" >&2
     exit -1
 fi
 
 while read line # Read configurations from file
 do
-    if echo $line | grep -F = &>/dev/null
+    varname=$(echo "$line" | sed "s/^\(..*\)\s*\=\s*..*$/\1/")
+    if [ "$varname" = "devsim_cmd_msg_pipe " ]
     then
-        varname=$(echo "$line" | sed "s/^\(..*\)\s*\=\s*..*$/\1/")
-        if [ $varname == "devsim_cmd_msg_pipe" ]; then
-            value=$(echo "$line" | sed "s/^..*\s*\=\s*\(..*\)$/\1/")
-            discovery_messenger_pipe=$value
-        fi
+        value=$(echo "$line" | sed "s/^..*\s*\=\s*\(..*\)$/\1/")
+        discovery_messenger_pipe=$value
+        break
     fi
 done < $liota_config
 
-if [ "$discovery_messenger_pipe" == "" ]; then
+if [ "$discovery_messenger_pipe" = "" ]
+then
     echo "ERROR: Discovery pipe path not found in configuration file" >&2
     exit -2
 fi
 
-if [ ! -p "$discovery_messenger_pipe" ]; then
+if [ ! -p "$discovery_messenger_pipe" ]
+then
     echo "ERROR: Discovery Pipe path is not a named pipe" >&2
-    #exit -3
+    exit -3
 fi
 
 # Echo to named pipe

--- a/packages/dev_disc/liota_disc_pipe.sh
+++ b/packages/dev_disc/liota_disc_pipe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------#
 #  Copyright © 2015-2016 VMware, Inc. All Rights Reserved.                    #
@@ -34,31 +34,33 @@
 liota_config="/etc/liota/liota.conf"
 discovery_messenger_pipe=""
 
-if [ ! -f "$liota_config" ]; then
+if [ ! -f "$liota_config" ]
+then
     echo "ERROR: Configuration file not found" >&2
     exit -1
 fi
 
 while read line # Read configurations from file
 do
-    if echo $line | grep -F = &>/dev/null
+    varname=$(echo "$line" | sed "s/^\(..*\)\s*\=\s*..*$/\1/")
+    if [ "$varname" = "disc_cmd_msg_pipe " ]
     then
-        varname=$(echo "$line" | sed "s/^\(..*\)\s*\=\s*..*$/\1/")
-        if [ $varname == "disc_cmd_msg_pipe" ]; then
-            value=$(echo "$line" | sed "s/^..*\s*\=\s*\(..*\)$/\1/")
-            discovery_messenger_pipe=$value
-        fi
+        value=$(echo "$line" | sed "s/^..*\s*\=\s*\(..*\)$/\1/")
+        discovery_messenger_pipe=$value
+        break
     fi
 done < $liota_config
 
-if [ "$discovery_messenger_pipe" == "" ]; then
+if [ "$discovery_messenger_pipe" = "" ]
+then
     echo "ERROR: Discovery pipe path not found in configuration file" >&2
     exit -2
 fi
 
-if [ ! -p "$discovery_messenger_pipe" ]; then
+if [ ! -p "$discovery_messenger_pipe" ]
+then
     echo "ERROR: Discovery Pipe path is not a named pipe" >&2
-    #exit -3
+    exit -3
 fi
 
 # Echo to named pipe

--- a/packages/liotapkg.sh
+++ b/packages/liotapkg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 # -*- coding: utf-8 -*-
 # ----------------------------------------------------------------------------#
 #  Copyright © 2015-2016 VMware, Inc. All Rights Reserved.                    #
@@ -34,7 +34,8 @@
 liota_config="/etc/liota/liota.conf"
 package_messenger_pipe=""
 
-if [ ! -f "$liota_config" ]; then
+if [ ! -f "$liota_config" ]
+then
     echo "ERROR: Configuration file not found" >&2
     echo "You made need to copy the distributed configuration file from /usr/lib/liota/config/liota.conf to /etc/liota/liota.conf" >&2
     exit -1
@@ -42,22 +43,23 @@ fi
 
 while read line # Read configurations from file
 do
-    if echo $line | grep -F = &>/dev/null
+    varname=$(echo "$line" | sed "s/^\(..*\)\s*\=\s*..*$/\1/")
+    if [ "$varname" = "pkg_msg_pipe " ]
     then
-        varname=$(echo "$line" | sed "s/^\(..*\)\s*\=\s*..*$/\1/")
-        if [ $varname == "pkg_msg_pipe" ]; then
-            value=$(echo "$line" | sed "s/^..*\s*\=\s*\(..*\)$/\1/")
-            package_messenger_pipe=$value
-        fi
+        value=$(echo "$line" | sed "s/^..*\s*\=\s*\(..*\)$/\1/")
+        package_messenger_pipe=$value
+        break
     fi
 done < $liota_config
 
-if [ "$package_messenger_pipe" == "" ]; then
+if [ "$package_messenger_pipe" = "" ]
+then
     echo "ERROR: Pipe path not found in configuration file" >&2
     exit -2
 fi
 
-if [ ! -p "$package_messenger_pipe" ]; then
+if [ ! -p "$package_messenger_pipe" ]
+then
     echo "ERROR: Pipe path is not a named pipe" >&2
     exit -3
 fi


### PR DESCRIPTION
1. Replace Bash with Bourne shell syntax to remove bash command dependancy
2. change path of liota generated temporary files to the "/var/tmp" directory,
and reusable files to the "/usr/lib/" directory:
	a) "/etc/liota/conf/devs" to "/var/tmp/liota/devs"
	b) "/etc/liota/conf/entity" to "/usr/lib/liota/entity"
	c) "/etc/liota/conf/iotcc.json" to "/var/tmp/liota/iotcc.json"
3. remove "uuid.ini" since "iotcc.json" stores edge system and devices info