### PR TITLE
Unit Handling

### DIFF
--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -90,8 +90,8 @@ class IotControlCenter(DataCenterComponent):
                     else:
                         raise Exception("Helix Protocol Version mismatch")
                 else:
-                    log.debug("Processed msg: {0}".format(json_msg["type"]))
                     on_response(self.recv_msg_queue.get(True, timeout))
+                    log.debug("Processed msg: {0}".format(json_msg["type"]))
 
             # Block on Queue for not more then 300 seconds else it will raise an exception
             on_response(self.recv_msg_queue.get(True, timeout))

--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -157,7 +157,8 @@ class IotControlCenter(DataCenterComponent):
                         self.remove_reg_entity_details(entity_obj.ref_entity.name, entity_obj.reg_entity_id)
                         self.store_device_info(entity_obj.reg_entity_id, entity_obj.ref_entity.name, None, None, True)
                 else:
-                    log.info("Unregistration of resource {0} with IoTCC failed".format(entity_obj.ref_entity.name))
+                    log.info("Waiting for unregistration response")
+                    on_response(self.recv_msg_queue.get(True, 20))
             except:
                 raise Exception("Exception while unregistering resource")
 

--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -31,6 +31,7 @@
 # ----------------------------------------------------------------------------#
 
 import json
+import sys
 import logging
 import time
 import threading
@@ -159,8 +160,8 @@ class IotControlCenter(DataCenterComponent):
                 else:
                     log.info("Waiting for unregistration response")
                     on_response(self.recv_msg_queue.get(True, 20))
-            except:
-                raise Exception("Exception while unregistering resource")
+            except Exception as e:
+                    raise Exception("Exception while unregistering resource: %s" % e, sys.exc_info()[2])
 
         self.comms.send(json.dumps(self._unregistration(self.next_id(), entity_obj.ref_entity)))
         on_response(self.recv_msg_queue.get(True, 20))

--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -159,9 +159,8 @@ class IotControlCenter(DataCenterComponent):
                 else:
                     log.info("Waiting for unregistration response")
                     on_response(self.recv_msg_queue.get(True, 20))
-            except Exception as err:
-                log.exception("Exception while unregistering resource")
-                raise err
+            except:
+                raise Exception("Exception while unregistering resource")
 
         self.comms.send(json.dumps(self._unregistration(self.next_id(), entity_obj.ref_entity)))
         on_response(self.recv_msg_queue.get(True, 20))

--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -150,6 +150,12 @@ class IotControlCenter(DataCenterComponent):
                 self._check_version(json_msg)
                 if json_msg["type"] == "remove_resource_response" and json_msg["body"]["result"] == "succeeded":
                     log.info("Unregistration of resource {0} with IoTCC succeeded".format(entity_obj.ref_entity.name))
+                    if entity_obj.ref_entity.entity_type != "HelixGateway":
+                        self.store_device_info(entity_obj.reg_entity_id, entity_obj.ref_entity.name,
+                                               entity_obj.ref_entity.entity_type, None, True)
+                    else:
+                        self.remove_reg_entity_details(entity_obj.ref_entity.name, entity_obj.reg_entity_id)
+                        self.store_device_info(entity_obj.reg_entity_id, entity_obj.ref_entity.name, None, None, True)
                 else:
                     log.info("Unregistration of resource {0} with IoTCC failed".format(entity_obj.ref_entity.name))
             except:
@@ -157,14 +163,6 @@ class IotControlCenter(DataCenterComponent):
 
         self.comms.send(json.dumps(self._unregistration(self.next_id(), entity_obj.ref_entity)))
         on_response(self.recv_msg_queue.get(True, 20))
-        if entity_obj.ref_entity.entity_type != "HelixGateway":
-            self.store_device_info(entity_obj.reg_entity_id, entity_obj.ref_entity.name,
-                                   entity_obj.ref_entity.entity_type, None, True)
-        else:
-            self.remove_reg_entity_details(entity_obj.ref_entity.name, entity_obj.reg_entity_id)
-            self.store_device_info(entity_obj.reg_entity_id, entity_obj.ref_entity.name, None, None, True)
-
-        log.info("Unregistration of resource {0} with IoTCC complete".format(entity_obj.ref_entity.name))
 
     def create_relationship(self, reg_entity_parent, reg_entity_child):
         """ This function initializes all relations between Registered Entities.
@@ -184,12 +182,15 @@ class IotControlCenter(DataCenterComponent):
             # should save parent's reg_entity_id
             reg_entity_child.reg_entity_id = reg_entity_parent.reg_entity_id
             entity_obj = reg_entity_child.ref_entity
-            self.publish_unit(reg_entity_child, entity_obj.name, entity_obj.unit)
+            # If the units are passed from user code they`ll be set as unit properties
+            if entity_obj.unit is not None:
+                self.publish_unit(reg_entity_child, entity_obj.name, entity_obj.unit)
         else:
             self.comms.send(json.dumps(self._relationship(self.next_id(),
                                                           reg_entity_parent.reg_entity_id,
                                                           reg_entity_child.reg_entity_id)))
-            self.set_system_properties(reg_entity_child, reg_entity_parent.sys_properties)
+            if hasattr(reg_entity_parent, 'sys_properties') and reg_entity_parent.sys_properties:
+                self.set_system_properties(reg_entity_child, reg_entity_parent.sys_properties)
 
     def _registration(self, msg_id, res_id, res_name, res_kind):
         return {

--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -159,8 +159,9 @@ class IotControlCenter(DataCenterComponent):
                 else:
                     log.info("Waiting for unregistration response")
                     on_response(self.recv_msg_queue.get(True, 20))
-            except:
-                raise Exception("Exception while unregistering resource")
+            except Exception as err:
+                log.exception("Exception while unregistering resource")
+                raise err
 
         self.comms.send(json.dumps(self._unregistration(self.next_id(), entity_obj.ref_entity)))
         on_response(self.recv_msg_queue.get(True, 20))


### PR DESCRIPTION
1. Only set the unit if they are passed from the user code.

2. Corrected the un-registration call, the entry should be deleted from iotcc.json file only if the resource is deleted successfully.

3. Adding a check for setting system properties for device entities.