### PR TITLE
Validating names and properties against a whitelist character set supported by IoTCC

### DIFF
--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -247,19 +247,15 @@ class IotControlCenter(DataCenterComponent):
         }
         for key, value in properties.items():
             if not self._validate_input(key):
-                log.error("Property key {0} contains unacceptable character for resource {1}".format(key, entity_name))
-                continue
+                raise ValueError("Property key {0} contains unacceptable character for resource {1}".format(key, entity_name))
             if not len(key) <= 100:
-                log.error("Property key {0} for resource {1} contains more than 100 characters".format(key, entity_name))
-                continue
+                raise ValueError("Property key {0} for resource {1} contains more than 100 characters".format(key, entity_name))
             if not self._validate_input(value):
-                log.error("Property value {0} of key {1} contains unacceptable character for resource {2}"
+                raise ValueError("Property value {0} of key {1} contains unacceptable character for resource {2}"
                           .format(value, key, entity_name))
-                continue
             if not len(value) <= 255:
-                log.error("Property value {0} of key {1} for resource {2} contains more than 255 characters"
+                raise ValueError("Property value {0} of key {1} for resource {2} contains more than 255 characters"
                           .format(value, key, entity_name))
-                continue
             msg["body"]["property_data"].append({"propertyKey": key, "propertyValue": value})
         return msg
 

--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -91,9 +91,13 @@ class IotControlCenter(DataCenterComponent):
 
         """
         if not self._validate_input(entity_obj.name):
-            raise Exception("Name of the resource contains unacceptable character : " + entity_obj.name)
+            raise ValueError("Name of the resource contains unacceptable character : " + entity_obj.name)
+        if not len(entity_obj.name) <= 50:
+            raise ValueError("Name of the resource contains more than 50 characters : " + entity_obj.name)
         if not self._validate_input(entity_obj.entity_type):
-            raise Exception("Type of the resource contains unacceptable character : " + entity_obj.entity_type)
+            raise ValueError("Type of the resource contains unacceptable character : " + entity_obj.entity_type)
+        if not len(entity_obj.entity_type) <= 50:
+            raise ValueError("Type of the resource contains more than 50 characters : " + entity_obj.entity_type)
 
         if isinstance(entity_obj, Metric):
             # reg_entity_id should be parent's one: not known here yet
@@ -245,8 +249,16 @@ class IotControlCenter(DataCenterComponent):
             if not self._validate_input(key):
                 log.error("Property key {0} contains unacceptable character for resource {1}".format(key, entity_name))
                 continue
+            if not len(key) <= 100:
+                log.error("Property key {0} for resource {1} contains more than 100 characters".format(key, entity_name))
+                continue
             if not self._validate_input(value):
-                log.error("Property value {0} of key {1} contains unacceptable character for resource {2}".format(value, key, entity_name))
+                log.error("Property value {0} of key {1} contains unacceptable character for resource {2}"
+                          .format(value, key, entity_name))
+                continue
+            if not len(value) <= 255:
+                log.error("Property value {0} of key {1} for resource {2} contains more than 255 characters"
+                          .format(value, key, entity_name))
                 continue
             msg["body"]["property_data"].append({"propertyKey": key, "propertyValue": value})
         return msg

--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -89,6 +89,9 @@ class IotControlCenter(DataCenterComponent):
         """ Register the objects
 
         """
+        if not self._validate_input(entity_obj.name):
+            raise Exception("Name of the resource contains unacceptable character : " + entity_obj.name)
+
         if isinstance(entity_obj, Metric):
             # reg_entity_id should be parent's one: not known here yet
             # will add in creat_relationship(); publish_unit should be done inside
@@ -236,6 +239,12 @@ class IotControlCenter(DataCenterComponent):
             }
         }
         for key, value in properties.items():
+            if not self._validate_input(key):
+                log.error("Property key {0} contains unacceptable character for resource {1}".format(key, entity_name))
+                continue
+            if not self._validate_input(value):
+                log.error("Property value {0} of key {1} contains unacceptable character for resource {2}".format(value, key, entity_name))
+                continue
             msg["body"]["property_data"].append({"propertyKey": key, "propertyValue": value})
         return msg
 
@@ -672,3 +681,10 @@ class IotControlCenter(DataCenterComponent):
         self.comms.send(json.dumps(self._get_properties(self.next_id(), resource_uuid)))
         on_response(self.recv_msg_queue.get(True, timeout))
         return self.prop_list
+
+    def _validate_input(self, input):
+        """ validates if the input string contains only the whitelisted characters """
+        import re
+        if not re.match('^[A-Za-z0-9\s\._-]+$', input):
+            return False
+        return True

--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -90,14 +90,8 @@ class IotControlCenter(DataCenterComponent):
         """ Register the objects
 
         """
-        if not self._validate_input(entity_obj.name):
-            raise ValueError("Name of the resource contains unacceptable character : " + entity_obj.name)
-        if not len(entity_obj.name) <= 50:
-            raise ValueError("Name of the resource contains more than 50 characters : " + entity_obj.name)
-        if not self._validate_input(entity_obj.entity_type):
-            raise ValueError("Type of the resource contains unacceptable character : " + entity_obj.entity_type)
-        if not len(entity_obj.entity_type) <= 50:
-            raise ValueError("Type of the resource contains more than 50 characters : " + entity_obj.entity_type)
+        self._assert_input(entity_obj.name, 50)
+        self._assert_input(entity_obj.entity_type, 50)
 
         if isinstance(entity_obj, Metric):
             # reg_entity_id should be parent's one: not known here yet
@@ -246,16 +240,8 @@ class IotControlCenter(DataCenterComponent):
             }
         }
         for key, value in properties.items():
-            if not self._validate_input(key):
-                raise ValueError("Property key {0} contains unacceptable character for resource {1}".format(key, entity_name))
-            if not len(key) <= 100:
-                raise ValueError("Property key {0} for resource {1} contains more than 100 characters".format(key, entity_name))
-            if not self._validate_input(value):
-                raise ValueError("Property value {0} of key {1} contains unacceptable character for resource {2}"
-                          .format(value, key, entity_name))
-            if not len(value) <= 255:
-                raise ValueError("Property value {0} of key {1} for resource {2} contains more than 255 characters"
-                          .format(value, key, entity_name))
+            self._assert_input(key, 100)
+            self._assert_input(value, 255)
             msg["body"]["property_data"].append({"propertyKey": key, "propertyValue": value})
         return msg
 
@@ -693,8 +679,10 @@ class IotControlCenter(DataCenterComponent):
         on_response(self.recv_msg_queue.get(True, timeout))
         return self.prop_list
 
-    def _validate_input(self, input):
+    def _assert_input(self, input, max_length):
         """ validates if the input string contains only the whitelisted characters """
         if not match('^[A-Za-z0-9\s\._-]+$', input):
-            return False
-        return True
+            raise ValueError("The provided string contains unacceptable character : {0}".format(input))
+        if not len(input) <= max_length:
+            raise ValueError("The provided string contains more than {0} characters : {1}" .format(max_length, input))
+        return

--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -42,6 +42,7 @@ import datetime
 from time import gmtime, strftime
 from uptime import boottime
 from threading import Lock
+from re import match
 
 from liota.dccs.dcc import DataCenterComponent, RegistrationFailure
 from liota.entities.metrics.metric import Metric
@@ -91,6 +92,8 @@ class IotControlCenter(DataCenterComponent):
         """
         if not self._validate_input(entity_obj.name):
             raise Exception("Name of the resource contains unacceptable character : " + entity_obj.name)
+        if not self._validate_input(entity_obj.entity_type):
+            raise Exception("Type of the resource contains unacceptable character : " + entity_obj.entity_type)
 
         if isinstance(entity_obj, Metric):
             # reg_entity_id should be parent's one: not known here yet
@@ -684,7 +687,6 @@ class IotControlCenter(DataCenterComponent):
 
     def _validate_input(self, input):
         """ validates if the input string contains only the whitelisted characters """
-        import re
-        if not re.match('^[A-Za-z0-9\s\._-]+$', input):
+        if not match('^[A-Za-z0-9\s\._-]+$', input):
             return False
         return True


### PR DESCRIPTION

IoTCC expects names and properties to have only characters like - alphabets, digits, underscore, hyphen , dot , space. No other characters accepted