### PR TITLE
Updating boottime to dcc load time

### DIFF
--- a/liota-lite/requirements.txt
+++ b/liota-lite/requirements.txt
@@ -2,4 +2,3 @@ aenum==1.4.5
 linux-metrics==0.1.4
 paho-mqtt==1.3.1
 pint==0.7.2
-uptime==3.0.1

--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -40,7 +40,6 @@ import os
 import Queue
 import datetime
 from time import gmtime, strftime
-
 from threading import Lock
 
 from liota.dccs.dcc import DataCenterComponent, RegistrationFailure
@@ -59,6 +58,7 @@ class IotControlCenter(DataCenterComponent):
 
     def __init__(self, con):
         log.info("Logging into DCC")
+        self._dcc_load_time = datetime.datetime.now()
         self._version = 20171023
         self.comms = con
         if not self.comms.identity.username:
@@ -78,14 +78,6 @@ class IotControlCenter(DataCenterComponent):
         self.enable_reboot_getprop = read_liota_config('IOTCC_PATH', 'enable_reboot_getprop')
         self.counter = 0
         self.recv_msg_queue = self.comms.userdata
-        try:
-            # TODO: For Windows system the alternate code should be provided
-            with open('/proc/uptime', 'r') as f:
-                uptime_seconds = float(f.readline().split()[0])
-                self.boottime = (datetime.datetime.now() - datetime.timedelta(seconds=uptime_seconds)).replace(microsecond=0)
-        except Exception as err:
-            log.exception("Exception while retrieving the boot time of the system")
-            raise err
         self.dev_file_path = self._get_file_storage_path("dev_file_path")
         # Liota internal entity file system path special for iotcc
         self.entity_file_path = self._get_file_storage_path("entity_file_path")
@@ -569,7 +561,7 @@ class IotControlCenter(DataCenterComponent):
             # check Entity_Timestamp of entity_file: if < boottime, get properties from cloud
             if (self.enable_reboot_getprop == "True") and ('Entity_Timestamp' in tmp_dict):
                 last_dtime = datetime.datetime.strptime(tmp_dict["Entity_Timestamp"], "%Y-%m-%dT%H:%M:%S")
-                if (last_dtime <= self.boottime):
+                if (last_dtime <= self._dcc_load_time):
                     list_prop = self.get_properties(reg_entity_id)
                     # merge property info from get_properties() into our local entity record
                     tmp_dict = self.merge_prop_dict_list(tmp_dict, list_prop)

--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -40,7 +40,7 @@ import os
 import Queue
 import datetime
 from time import gmtime, strftime
-from uptime import boottime
+
 from threading import Lock
 
 from liota.dccs.dcc import DataCenterComponent, RegistrationFailure
@@ -78,8 +78,14 @@ class IotControlCenter(DataCenterComponent):
         self.enable_reboot_getprop = read_liota_config('IOTCC_PATH', 'enable_reboot_getprop')
         self.counter = 0
         self.recv_msg_queue = self.comms.userdata
-        self.boottime = boottime()
-
+        try:
+            # TODO: For Windows system the alternate code should be provided
+            with open('/proc/uptime', 'r') as f:
+                uptime_seconds = float(f.readline().split()[0])
+                self.boottime = (datetime.datetime.now() - datetime.timedelta(seconds=uptime_seconds)).replace(microsecond=0)
+        except Exception as err:
+            log.exception("Exception while retrieving the boot time of the system")
+            raise err
         self.dev_file_path = self._get_file_storage_path("dev_file_path")
         # Liota internal entity file system path special for iotcc
         self.entity_file_path = self._get_file_storage_path("entity_file_path")

--- a/liota/dccs/iotcc.py
+++ b/liota/dccs/iotcc.py
@@ -558,7 +558,7 @@ class IotControlCenter(DataCenterComponent):
                 new_prop_dict = tmp_dict
         else:
             tmp_dict = self.read_entity_file(reg_entity_id)
-            # check Entity_Timestamp of entity_file: if < boottime, get properties from cloud
+            # check Entity_Timestamp of entity_file: if < _dcc_load_time, get properties from cloud
             if (self.enable_reboot_getprop == "True") and ('Entity_Timestamp' in tmp_dict):
                 last_dtime = datetime.datetime.strptime(tmp_dict["Entity_Timestamp"], "%Y-%m-%dT%H:%M:%S")
                 if (last_dtime <= self._dcc_load_time):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ mock==2.0.0
 paho-mqtt==1.3.1
 pint==0.7.2
 websocket-client==0.37.0
-uptime==3.0.1


### PR DESCRIPTION
Updating boottime to dcc load time. As per discussion in below thread:

https://urldefense.proofpoint.com/v2/url?u=https-3A__github.com_vmware_liota_commit_fb2009dead31d938986b3da73f34e4106da7b3b1-23commitcomment-2D25587352&d=DwMFaQ&c=uilaK90D4TOVoH58JNXRgQ&r=X3NPadWXl24V5Sdg4xOOrRTK2XrD7UjZeVRuYt_RSJ4&m=nlR88KsQpyjxBprkxqcXMq3N6RnCBxY5gSS6T0JfF_s&s=kjACz4zqWDZ_ZK0aqng9WWuXpyTS-ZF4nZznawY7WaM&e=