### PR TITLE
Let package manager return command execution status:

### DIFF
--- a/config/liota.conf
+++ b/config/liota.conf
@@ -20,6 +20,7 @@ collect_thread_pool_size = 30
 [PKG_CFG]
 pkg_path = /usr/lib/liota/packages
 pkg_msg_pipe = /usr/lib/liota/packages/liotad/package_messenger.fifo
+pkg_rsp_pipe = /usr/lib/liota/packages/liotad/package_responser.fifo
 pkg_list = /usr/lib/liota/packages/liotad/packages_auto.txt
 
 [DISC_CFG]

--- a/config/liota.conf
+++ b/config/liota.conf
@@ -20,7 +20,7 @@ collect_thread_pool_size = 30
 [PKG_CFG]
 pkg_path = /usr/lib/liota/packages
 pkg_msg_pipe = /usr/lib/liota/packages/liotad/package_messenger.fifo
-pkg_rsp_pipe = /usr/lib/liota/packages/liotad/package_responser.fifo
+pkg_rsp_pipe = /usr/lib/liota/packages/liotad/package_response.fifo
 pkg_list = /usr/lib/liota/packages/liotad/packages_auto.txt
 
 [DISC_CFG]

--- a/liota/core/device_discovery.py
+++ b/liota/core/device_discovery.py
@@ -39,7 +39,7 @@ import ConfigParser
 from threading import Thread, Lock
 from Queue import Queue
 
-from liota.lib.utilities.utility import LiotaConfigPath, DiscUtilities
+from liota.lib.utilities.utility import LiotaConfigPath, validate_named_pipe
 from liota.disc_listeners.named_pipe import NamedPipeListener
 from liota.disc_listeners.socket_svr import SocketListener
 from liota.disc_listeners.mqtt import MqttListener
@@ -195,7 +195,7 @@ class DiscoveryThread(Thread):
         assert(isinstance(self.cmd_messenger_pipe, basestring))
 
     def _executable_check(self):
-        if DiscUtilities().validate_named_pipe(self.cmd_messenger_pipe) == False:
+        if validate_named_pipe(self.cmd_messenger_pipe) == False:
             return None
         # Will not initialize device discovery if DISCOVERY_LISTENER list is empty
         if len(self.endpoint_list) is 0:

--- a/liota/core/discovery_simulator.py
+++ b/liota/core/discovery_simulator.py
@@ -40,9 +40,7 @@ from threading import Thread, Lock
 from Queue import Queue
 from time import sleep
 
-from liota.lib.utilities.utility import LiotaConfigPath
-from liota.lib.utilities.utility import DiscUtilities
-from liota.lib.utilities.utility import read_user_config
+from liota.lib.utilities.utility import LiotaConfigPath, validate_named_pipe, read_user_config
 from liota.dev_sims.named_pipe import NamedPipeSimulator
 from liota.dev_sims.socket_clnt import SocketSimulator
 from liota.dev_sims.mqtt import MqttSimulator
@@ -218,7 +216,7 @@ class SimulatorThread(Thread):
         assert(isinstance(self.cmd_messenger_pipe, basestring))
 
     def _executable_check(self):
-        if DiscUtilities().validate_named_pipe(self.cmd_messenger_pipe) == False:
+        if validate_named_pipe(self.cmd_messenger_pipe) == False:
             return None
         # Will not initialize device simulator if simulator list is empty
         if len(self.endpoint_list) is 0:

--- a/liota/core/package_manager.py
+++ b/liota/core/package_manager.py
@@ -494,8 +494,8 @@ class PackageThread(Thread):
         """
         Write command status back to response named pipe.
         Currently, for commands of ["unload", "delete", "list", "stat",
-        "unload_all", "unload_all", "terminate"], 'Success' means
-        that PackageThread has successfully received these commands;
+        "unload_all", "terminate"], 'Success' means that PackageThread
+        has successfully received these commands;
         for commands of ["load", "reload", "update"], 'Success' means
         that verification of the package checksum succeeds, while
         'Failure' means that verification fails; 'Unsupported' means

--- a/liota/dev_sims/named_pipe.py
+++ b/liota/dev_sims/named_pipe.py
@@ -30,16 +30,12 @@
 #  THE POSSIBILITY OF SUCH DAMAGE.                                            #
 # ----------------------------------------------------------------------------#
 import os
-import sys
 import time
 import json
-import stat
 import fcntl
-import inspect
 import logging
-from Queue import Queue
 
-from liota.lib.utilities.utility import DiscUtilities
+from liota.lib.utilities.utility import validate_named_pipe
 from liota.dev_sims.device_simulator import DeviceSimulator
 
 log = logging.getLogger(__name__)
@@ -52,7 +48,7 @@ class NamedPipeSimulator(DeviceSimulator):
 
     def __init__(self, pipe_file, name=None, simulator=None):
         super(NamedPipeSimulator, self).__init__(name=name)
-        if DiscUtilities().validate_named_pipe(pipe_file) == False:
+        if validate_named_pipe(pipe_file) == False:
             return None
         self._pipe_file = pipe_file
         self.simulator = simulator # backpoint to simulator obj

--- a/liota/disc_listeners/named_pipe.py
+++ b/liota/disc_listeners/named_pipe.py
@@ -39,7 +39,7 @@ import logging
 from Queue import Queue
 from threading import Thread
 
-from liota.lib.utilities.utility import DiscUtilities
+from liota.lib.utilities.utility import validate_named_pipe
 from liota.disc_listeners.discovery_listener import DiscoveryListener
 
 log = logging.getLogger(__name__)
@@ -52,7 +52,7 @@ class NamedPipeListener(DiscoveryListener):
 
     def __init__(self, pipe_file, name=None, discovery=None):
         super(NamedPipeListener, self).__init__(name=name)
-        if DiscUtilities().validate_named_pipe(pipe_file) == False:
+        if validate_named_pipe(pipe_file) == False:
             return None
         self._pipe_file = pipe_file
         self.msg_queue = Queue()

--- a/liota/lib/utilities/utility.py
+++ b/liota/lib/utilities/utility.py
@@ -286,36 +286,28 @@ def read_user_config(config_file_path):
     return user_config
 
 
-class DiscUtilities:
-    """
-    DiscUtilities is a wrapper of utility functions
-    """
-
-    def __init__(self):
-        pass
-
-    def validate_named_pipe(self, pipe_file):
-        assert (isinstance(pipe_file, basestring))
-        if os.path.exists(pipe_file):
-            if stat.S_ISFIFO(os.stat(pipe_file).st_mode):
-                pass
-            else:
-                log.error("Pipe path exists, but it is not a pipe")
-                return False
+def validate_named_pipe(pipe_file):
+    assert (isinstance(pipe_file, basestring))
+    if os.path.exists(pipe_file):
+        if stat.S_ISFIFO(os.stat(pipe_file).st_mode):
+            pass
         else:
-            pipe_dir = os.path.dirname(pipe_file)
-            if not os.path.isdir(pipe_dir):
-                try:
-                    os.makedirs(pipe_dir)
-                    log.info("Created directory: " + pipe_dir)
-                except OSError:
-                    log.error("Could not create directory for messenger pipe")
-                    return False
+            log.error("Pipe path exists, but it is not a pipe")
+            return False
+    else:
+        pipe_dir = os.path.dirname(pipe_file)
+        if not os.path.isdir(pipe_dir):
             try:
-                os.mkfifo(pipe_file, 0600)
-                log.info("Created pipe: " + pipe_file)
+                os.makedirs(pipe_dir)
+                log.info("Created directory: " + pipe_dir)
             except OSError:
-                log.error("Could not create messenger pipe")
+                log.error("Could not create directory for pipe")
                 return False
-        assert (stat.S_ISFIFO(os.stat(pipe_file).st_mode))
-        return True
+        try:
+            os.mkfifo(pipe_file, 0600)
+            log.info("Created pipe: " + pipe_file)
+        except OSError:
+            log.error("Could not create pipe")
+            return False
+    assert (stat.S_ISFIFO(os.stat(pipe_file).st_mode))
+    return True

--- a/packages/liotad/README.md
+++ b/packages/liotad/README.md
@@ -79,6 +79,16 @@ PackageMessengerThread listens on a named pipe whose location is defined in `lio
 
 Different techniques can be supported in PackageMessengerThread in the future.
 
+###Command Status Return
+
+Once liotapkg.sh passes commands to PackageThread through PackageMessengerThread,
+it will read from response namedPipe to get command status.
+For commands of ["unload", "delete", "list", "stat", "unload_all", "terminate"],
+'Success' means that PackageThread has successfully received these commands;
+for commands of ["load", "reload", "update"], 'Success' means that verification
+of the package checksum succeeds, while 'Failure' means that verification fails;
+'Unsupported' means that receives some unsupported commands.
+
 ##LiotaPackage
 
 There is a LiotaPackage class defined in `package_manager.py` which looks like

--- a/packages/liotad/liotapkg.sh
+++ b/packages/liotad/liotapkg.sh
@@ -33,18 +33,19 @@
 
 liota_config="/etc/liota/liota.conf"
 package_messenger_pipe=""
+package_responser_pipe=""
 
 if ! [ `ps -ef | grep "liotad.py" | grep -v grep | wc -l` -gt 0 ]
 then
         echo "Liota package manager is not running. Please run it first!"
-        exit -1
+        exit 1
 fi
 
 if [ ! -f "$liota_config" ]
 then
     echo "ERROR: Configuration file not found" >&2
     echo "You made need to copy the distributed configuration file from /usr/lib/liota/config/liota.conf to /etc/liota/liota.conf" >&2
-    exit -2
+    exit 2
 fi
 
 while read line # Read configurations from file
@@ -54,22 +55,50 @@ do
     then
         value=$(echo "$line" | sed "s/^..*\s*\=\s*\(..*\)$/\1/")
         package_messenger_pipe=$value
-        break
+        if [ "$package_responser_pipe" != "" ]
+        then
+            break
+        fi
+    fi
+    if [ "$varname" = "pkg_rsp_pipe " ]
+    then
+        value=$(echo "$line" | sed "s/^..*\s*\=\s*\(..*\)$/\1/")
+        package_responser_pipe=$value
+        if [ "$package_messenger_pipe" != "" ]
+        then
+            break
+        fi
     fi
 done < $liota_config
 
 if [ "$package_messenger_pipe" = "" ]
 then
-    echo "ERROR: Pipe path not found in configuration file" >&2
-    exit -3
+    echo "ERROR: Messenger Pipe path not found in configuration file" >&2
+    exit 3
 fi
 
 if [ ! -p "$package_messenger_pipe" ]
 then
-    echo "ERROR: Pipe path is not a named pipe" >&2
-    exit -4
+    echo "ERROR: Messenger Pipe path is not a named pipe" >&2
+    exit 4
+fi
+
+if [ "$package_responser_pipe" = "" ]
+then
+    echo "ERROR: Responser Pipe path not found in configuration file" >&2
+    exit 5
+fi
+
+if [ ! -p "$package_responser_pipe" ]
+then
+    echo "ERROR: Responser Pipe path is not a named pipe" >&2
+    exit 6
 fi
 
 # Echo to named pipe
 echo "Pipe file: $package_messenger_pipe" >&2
 echo "$@" > $package_messenger_pipe
+# read result
+if read line <$package_responser_pipe; then
+    echo $line
+fi

--- a/packages/liotad/liotapkg.sh
+++ b/packages/liotad/liotapkg.sh
@@ -96,7 +96,7 @@ then
 fi
 
 # Echo to named pipe
-echo "Pipe file: $package_messenger_pipe" >&2
+#echo "Pipe file: $package_messenger_pipe" >&2
 echo "$@" > $package_messenger_pipe
 # read result
 if read line <$package_response_pipe; then

--- a/packages/liotad/liotapkg.sh
+++ b/packages/liotad/liotapkg.sh
@@ -33,7 +33,7 @@
 
 liota_config="/etc/liota/liota.conf"
 package_messenger_pipe=""
-package_responser_pipe=""
+package_response_pipe=""
 
 if ! [ `ps -ef | grep "liotad.py" | grep -v grep | wc -l` -gt 0 ]
 then
@@ -55,7 +55,7 @@ do
     then
         value=$(echo "$line" | sed "s/^..*\s*\=\s*\(..*\)$/\1/")
         package_messenger_pipe=$value
-        if [ "$package_responser_pipe" != "" ]
+        if [ "$package_response_pipe" != "" ]
         then
             break
         fi
@@ -63,7 +63,7 @@ do
     if [ "$varname" = "pkg_rsp_pipe " ]
     then
         value=$(echo "$line" | sed "s/^..*\s*\=\s*\(..*\)$/\1/")
-        package_responser_pipe=$value
+        package_response_pipe=$value
         if [ "$package_messenger_pipe" != "" ]
         then
             break
@@ -83,13 +83,13 @@ then
     exit 4
 fi
 
-if [ "$package_responser_pipe" = "" ]
+if [ "$package_response_pipe" = "" ]
 then
     echo "ERROR: Responser Pipe path not found in configuration file" >&2
     exit 5
 fi
 
-if [ ! -p "$package_responser_pipe" ]
+if [ ! -p "$package_response_pipe" ]
 then
     echo "ERROR: Responser Pipe path is not a named pipe" >&2
     exit 6
@@ -99,6 +99,6 @@ fi
 echo "Pipe file: $package_messenger_pipe" >&2
 echo "$@" > $package_messenger_pipe
 # read result
-if read line <$package_responser_pipe; then
+if read line <$package_response_pipe; then
     echo $line
 fi


### PR DESCRIPTION
1. package manager creates one more namedPipe to pass status
2. once user passes commands to messenger namedPipe through liotapkg,
liotapkg will read from reponser namedPipe to get status
3. for commands of ["unload", "delete", "list", "stat", "unload_all",
   "unload_all", "terminate"], 'Success' means that package manager
   has successfully received these commands;
   for commands of ["load", "reload", "update"], 'Success' means that
   verification of the package checksum succeeds, while 'Failure'
   means that verification fails;
   'Unsupported' means that receives some unsupported commands.