### PR TITLE
Changes to fix issues when package name contains space character

### DIFF
--- a/liota/core/package_manager.py
+++ b/liota/core/package_manager.py
@@ -476,7 +476,7 @@ class PackageThread(Thread):
         while self.flag_alive:
             msg = package_message_queue.get()
             log.info("Got message in package messenger queue: %s"
-                     % " ".join(msg))
+                     % ",".join(msg))
             if not isinstance(msg, tuple) and not isinstance(msg, list):
                 raise TypeError(type(msg))
 
@@ -670,7 +670,7 @@ class PackageThread(Thread):
         if isinstance(package_startup_list_path, basestring):
             try:
                 with open(package_startup_list_path, "r+") as fp:
-                    output_list = fp.read().split()
+                    output_list = fp.read().splitlines()
                     fp.seek(0)
                     for values in output_list:
                         k, v = values.split(":")
@@ -702,7 +702,7 @@ class PackageThread(Thread):
         if isinstance(package_startup_list_path, basestring):
             try:
                 with open(package_startup_list_path, "r+") as fp:
-                    output_list = fp.read().split()
+                    output_list = fp.read().splitlines()
                     fp.seek(0)
                     for values in output_list:
                         k, v = values.split(":")
@@ -1184,7 +1184,7 @@ class PackageThread(Thread):
         if isinstance(package_startup_list_path, basestring):
             try:
                 with open(package_startup_list_path, "r") as fp:
-                    output_list = fp.read().split()
+                    output_list = fp.read().splitlines()
                 for values in output_list:
                     k, v = values.split(":")
                     package_startup_list.append({k: v})
@@ -1351,7 +1351,7 @@ class PackageMessengerThread(Thread):
         while self.flag_alive:
             with open(self._pipe_file, "r") as fp:
                 for line in fp.readlines():
-                    msg = line.split()
+                    msg = line.split(',')
                     if len(msg) > 0:
                         if len(msg) == 1 and msg[0] == \
                                 "terminate_messenger_but_you_should_not_do_this_yourself":

--- a/packages/liotad/README.md
+++ b/packages/liotad/README.md
@@ -45,6 +45,9 @@ Unload a package with the specified name and attempt to reload the same package.
 
 Remove a package with the specified name. By default, the removed package will be stashed into a separate folder in the package path, so package manager will not find it. However, if package manager fails to create the folder, or fails to move the file, the package file will be deleted from the file system.
 
+**Note:** If the package_name contains space or special characters, it should be enclosed with in single/double quotes.
+e.g., ./liotapkg.sh load -r 'filename 1' sha1_checksum
+
 ###Package Load Automation
 
 Load Liota Packages automatically when Package Manager starts by listing package names and checksums in the file specified by pkg_list in [PKG_CFG] of liota.conf, e.g., by default /usr/lib/liota/packages/packages_auto.txt (Should NOT have " " around ":"):

--- a/packages/liotad/liotapkg.sh
+++ b/packages/liotad/liotapkg.sh
@@ -95,9 +95,17 @@ then
     exit 6
 fi
 
+# Collect the supplied arguments and create a comma seperated string so that package manager can split using comma as
+# delimeter. The package name supplied could contain space character.
+comma_seperated_args="$1"
+shift
+for arg in "$@"; do
+	comma_seperated_args="$comma_seperated_args,$arg"
+done
+
 # Echo to named pipe
 #echo "Pipe file: $package_messenger_pipe" >&2
-echo "$@" > $package_messenger_pipe
+echo -n "$comma_seperated_args" > $package_messenger_pipe
 # read result
 if read line <$package_response_pipe; then
     echo $line


### PR DESCRIPTION
1. Changed message format written to the pipe from space char separated to comma char separated to allow space char in package names
2. Changed message read from the pipe to be split by comma char as delimiter
3. Used splitlines() instead of split() on the contents read from the packages_auto.txt to allow space char in package names