### PR TITLE
Default Value updated in Liota.conf 

### DIFF
--- a/config/liota.conf
+++ b/config/liota.conf
@@ -16,7 +16,7 @@ enable_reboot_getprop = False
 # The number of attempts to retry in order to read iotcc.json files
 iotcc_load_retry = 3
 # Configurable queue timeout in order to wait for the response messages from IOTCC
-iotcc_response_timeout = 300
+iotcc_response_timeout = 600
 # System Properties List to be set during registration of Edge System/Devices
 system_properties= {}
 


### PR DESCRIPTION
iotcc_response_timeout value updated to 600 as per test results.